### PR TITLE
Correctly parses the incoming payload as UTF-8, fixing checks for 👍

### DIFF
--- a/lib/hmac.js
+++ b/lib/hmac.js
@@ -11,7 +11,7 @@ const bufferEq = require('buffer-equal-constant-time');
 const createHmac = (key, text) => {
     const hmac = crypto.createHmac('sha1', key);
     hmac.setEncoding('hex');
-    hmac.write(text);
+    hmac.write(new Buffer(text, 'utf-8'));
     hmac.end();
     return 'sha1=' + hmac.read();
 };

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -38,7 +38,27 @@ describe('github webhook handler', () => {
         const payload = JSON.stringify({
             message: 'This message is valid!'
         });
-        const signature  = hmac.create(secret, payload);
+        const signature = 'sha1=725d3b6750a528d85390a1a81f908f838fce3c9e';
+        const options = {
+            method: "POST",
+            url: "/webhooks/github",
+            headers: {
+                'X-Hub-Signature': signature,
+                'Content-Type': 'application/json'
+            },
+            payload: payload
+        };
+
+        testServer.inject(options, function(response) {
+            expect(response.statusCode).to.equal(200, 'server responded with non-200 response');
+            done();
+        });
+    });
+    it('should return a status of 200 if the signature is valid and contains utf-8', (done) => {
+        const payload = JSON.stringify({
+            message: 'This message is valid! ⚠️'
+        });
+        const signature = 'sha1=bc132642e6d17e72204085106dd774cc33818a81';
         const options = {
             method: "POST",
             url: "/webhooks/github",


### PR DESCRIPTION
Ran into issues where PRs contained icons like the one above.  Turns out the default encoding of hmac is binary, but we need utf-8 to match what GitHub expects.

 - https://developer.github.com/webhooks/securing/
 - http://stackoverflow.com/questions/12195480/node-js-crypto-cannot-create-hmac-on-chars-with-accents

Fixes: https://github.com/screwdriver-cd/screwdriver/issues/246